### PR TITLE
GPLv2+ is not invalid

### DIFF
--- a/tests/license1.ref
+++ b/tests/license1.ref
@@ -1,2 +1,2 @@
 license1: E: invalid-license (Badness: 100000) BSD-2-Clause ; BSL-1.0
-1 packages and 0 specfiles checked; 1 error, 0 warnings.
+1 packages and 0 specfiles checked; 1 errors, 0 warnings.

--- a/tests/license1.ref
+++ b/tests/license1.ref
@@ -1,3 +1,2 @@
-license1: E: invalid-license (Badness: 100000) GPLv2+
 license1: E: invalid-license (Badness: 100000) BSD-2-Clause ; BSL-1.0
-1 packages and 0 specfiles checked; 2 errors, 0 warnings.
+1 packages and 0 specfiles checked; 1 error, 0 warnings.


### PR DESCRIPTION
GPLv2+ seems to valid in SPDX , so adjust the testcase