### PR TITLE
add checks for shlib-policy-name-error and "no dependency on *lib*"

### DIFF
--- a/tests/libzork4.spec
+++ b/tests/libzork4.spec
@@ -1,0 +1,67 @@
+%define soname 42
+%define basename zork
+
+Name:           zork4
+Version:        1.2.3
+Release:        0
+Group:          Development/Tools/Building
+Summary:        Lorem ipsum
+License:        GPL-2.0+
+BuildRoot:      %_tmppath/%name-%version-build
+Url:            http://www.opensuse.org/
+
+%description
+Lorem ipsum dolor sit amet, consectetur adipisici elit, sed
+eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim
+ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquid ex ea commodi consequat. Quis aute iure reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui
+officia deserunt mollit anim id est laborum.
+
+%package -n libzork%{soname}
+Group:          Development/Tools/Building
+Summary:        Lorem ipsum
+Provides:       %{name}-libs = %{version}
+
+%description -n libzork%{soname}
+Lorem ipsum dolor sit amet.
+
+%package devel
+Group:          Development/Tools/Building
+Summary:        Lorem ipsum
+# Does not fulfill requirement for corresponding library package ...
+Requires:       libzork%{soname}-aux
+Requires:       libzork%{soname}-data = %{version}
+# but this one does, so package is ok
+Requires:       %{name}-libs = %{version}
+
+%description devel
+Lorem ipsum dolor sit amet.
+
+%prep
+%build
+
+%install
+install -d -m 755 %buildroot/usr/lib
+echo "void foobar() {}" >xx.c
+gcc -O2 -shared -Wl,-soname,libzork.so.%{soname} xx.c -o %buildroot/usr/lib/libzork.so.%{soname}
+strip %buildroot/usr/lib/libzork.so.%{soname}
+ln -s libzork.so.%{soname} %buildroot/usr/lib/libzork.so
+
+%clean
+rm -rf %buildroot
+
+%post -n libzork%{soname} -p /sbin/ldconfig
+
+%postun -n libzork%{soname} -p /sbin/ldconfig
+
+%files -n libzork%{soname}
+/usr/lib/*so.*
+
+%files devel
+/usr/lib/*so
+
+%changelog
+* Mon Dec 12 2016 stefan.bruens@rwth-aachen.de
+- dummy

--- a/tests/libzork42.ref
+++ b/tests/libzork42.ref
@@ -1,0 +1,1 @@
+1 packages and 0 specfiles checked; 0 errors, 0 warnings.

--- a/tests/shlib3-devel.ref
+++ b/tests/shlib3-devel.ref
@@ -1,0 +1,2 @@
+shlib3-devel: W: no-dependency-on shlib3*/shlib3-libs/libshlib3*
+1 packages and 0 specfiles checked; 0 errors, 1 warnings.

--- a/tests/shlib3.ref
+++ b/tests/shlib3.ref
@@ -1,0 +1,2 @@
+shlib3: E: shlib-policy-name-error (Badness: 10000) libfoo3
+1 packages and 0 specfiles checked; 1 errors, 0 warnings.

--- a/tests/shlib3.spec
+++ b/tests/shlib3.spec
@@ -1,0 +1,53 @@
+Name:           shlib3
+Version:        0
+Release:        0
+Group:          Development/Tools/Building
+Summary:        Lorem ipsum
+License:        GPL-2.0+
+BuildRoot:      %_tmppath/%name-%version-build
+Url:            http://www.opensuse.org/
+
+%description
+Lorem ipsum dolor sit amet, consectetur adipisici elit, sed
+eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim
+ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquid ex ea commodi consequat. Quis aute iure reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui
+officia deserunt mollit anim id est laborum.
+
+%package devel
+Group:          Development/Tools/Building
+Summary:        Lorem ipsum
+# Does not fulfill requirement for corresponding library package
+Requires:       shlib3-aux = %{version}
+
+%description devel
+Lorem ipsum dolor sit amet.
+
+%prep
+%build
+
+%install
+install -d -m 755 %buildroot/usr/lib
+echo "void foobar() {}" >xx.c
+gcc -O2 -shared -Wl,-soname,libfoo.so.3 xx.c -o %buildroot/usr/lib/libfoo.so.3
+strip %buildroot/usr/lib/libfoo.so.3
+ln -s libfoo.so.3 %buildroot/usr/lib/libfoo.so
+
+%clean
+rm -rf %buildroot
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+/usr/lib/*so.*
+
+%files devel
+/usr/lib/*so
+
+%changelog
+* Mon Dec 12 2016 stefan.bruens@rwth-aachen.de
+- dummy

--- a/tests/zork4-devel.ref
+++ b/tests/zork4-devel.ref
@@ -1,0 +1,1 @@
+1 packages and 0 specfiles checked; 0 errors, 0 warnings.


### PR DESCRIPTION
shlib3.spec triggers both errors, whereas libzork4.spec checks for false
positives.
The latter is a typical example of a library package with non-matching
names for the library and its devel package. The name has been chosen
so zork-libs sorts after libzork-aux and libzork-data

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>