### PR TITLE
Add unit test for ErlangCheck

### DIFF
--- a/tests/erlang.ignore
+++ b/tests/erlang.ignore
@@ -1,0 +1,1 @@
+addCheck("ErlangCheck")

--- a/tests/erlang.ref
+++ b/tests/erlang.ref
@@ -1,0 +1,2 @@
+erlang: W: beam-compiled-without-debug_info /usr/lib64/erlang/m.beam
+1 packages and 0 specfiles checked; 0 errors, 1 warnings.

--- a/tests/erlang.spec
+++ b/tests/erlang.spec
@@ -1,0 +1,42 @@
+Name:		erlang
+Version:	0
+Release:	0
+Group:          Development/Tools/Building
+Summary:	Lorem ipsum
+License:	GPL-2.0+
+BuildRoot:	%_tmppath/%name-%version-build
+Url:            http://www.opensuse.org/
+
+%description
+Lorem ipsum dolor sit amet, consectetur adipisici elit, sed
+eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim
+ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquid ex ea commodi consequat. Quis aute iure reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui
+officia deserunt mollit anim id est laborum.
+
+%prep
+%build
+cat <<EOF > m.erl
+-module(m).
+-export([fact/1]).
+
+fact(N) when N>0 -> N * fact(N-1);
+fact(0) -> 1.
+EOF
+erlc +no_debug_info m.erl 
+
+%install
+install -D -m 644 m.beam %buildroot%_libdir/erlang/m.beam
+
+%clean
+rm -rf %buildroot
+
+%files
+%defattr(-,root,root)
+%_libdir/erlang/m.beam
+
+%changelog
+* Mon Apr 18 2011 lnussel@suse.de
+- dummy


### PR DESCRIPTION
Hello,

Recently there were two incidents when rpmlint ErlangCheck was broken by package updates in Factory and Leap:42.3.
To eliminate similar issues in future, the following unit test is provided.