### PR TITLE
Remove ldconfig-related warnings

### DIFF
--- a/tests/libzork4.spec
+++ b/tests/libzork4.spec
@@ -52,9 +52,7 @@ ln -s libzork.so.%{soname} %buildroot/usr/lib/libzork.so
 %clean
 rm -rf %buildroot
 
-%post -n libzork%{soname} -p /sbin/ldconfig
 
-%postun -n libzork%{soname} -p /sbin/ldconfig
 
 %files -n libzork%{soname}
 /usr/lib/*so.*

--- a/tests/shlib1.ref
+++ b/tests/shlib1.ref
@@ -1,7 +1,3 @@
 shlib1: W: unstripped-binary-or-object /usr/lib/libfoo-2.so
 shlib1: E: devel-file-in-non-devel-package (Badness: 50) /usr/lib/libfoo.so
-shlib1: E: library-without-ldconfig-postin (Badness: 300) /usr/lib/libfoo-2.so
-shlib1: E: library-without-ldconfig-postin (Badness: 300) /usr/lib/libfoo.so.1
-shlib1: E: library-without-ldconfig-postun (Badness: 300) /usr/lib/libfoo-2.so
-shlib1: E: library-without-ldconfig-postun (Badness: 300) /usr/lib/libfoo.so.1
 1 packages and 0 specfiles checked; 5 errors, 1 warnings.

--- a/tests/shlib2-devel.ref
+++ b/tests/shlib2-devel.ref
@@ -2,8 +2,4 @@ shlib2-devel: W: no-dependency-on shlib2*/shlib2-libs/libshlib2*
 shlib2-devel: W: non-devel-file-in-devel-package /usr/lib/libfoo-2.so
 shlib2-devel: W: non-devel-file-in-devel-package /usr/lib/libfoo.so.1
 shlib2-devel: W: unstripped-binary-or-object /usr/lib/libfoo-2.so
-shlib2-devel: E: library-without-ldconfig-postin (Badness: 300) /usr/lib/libfoo-2.so
-shlib2-devel: E: library-without-ldconfig-postin (Badness: 300) /usr/lib/libfoo.so.1
-shlib2-devel: E: library-without-ldconfig-postun (Badness: 300) /usr/lib/libfoo-2.so
-shlib2-devel: E: library-without-ldconfig-postun (Badness: 300) /usr/lib/libfoo.so.1
 1 packages and 0 specfiles checked; 4 errors, 4 warnings.

--- a/tests/shlib3.spec
+++ b/tests/shlib3.spec
@@ -38,9 +38,7 @@ ln -s libfoo.so.3 %buildroot/usr/lib/libfoo.so
 %clean
 rm -rf %buildroot
 
-%post -p /sbin/ldconfig
 
-%postun -p /sbin/ldconfig
 
 %files
 /usr/lib/*so.*


### PR DESCRIPTION

Removing those warnings will allow the implementation of **RPM file triggers** in **_Glibc_**'s specfile for automated `/sbin/ldconfig` call for libraries being installed under standard locations (`/lib`, `/lib64`, `/usr/lib` and `/usr/lib64`).