### PR TITLE
Add test for %tmpfiles_create foo.conf with no full path

### DIFF
--- a/tests/tmpfiles6.ignore
+++ b/tests/tmpfiles6.ignore
@@ -1,0 +1,3 @@
+#addFilter(" files-duplicate")
+#addFilter(" no-manual-page-for-binary ")
+#addFilter(" no-binary")

--- a/tests/tmpfiles6.ref
+++ b/tests/tmpfiles6.ref
@@ -1,0 +1,1 @@
+1 packages and 0 specfiles checked; 0 errors, 0 warnings.

--- a/tests/tmpfiles6.spec
+++ b/tests/tmpfiles6.spec
@@ -1,0 +1,42 @@
+Name:		tmpfiles6
+Version:	0
+Release:	0
+Group:          Development/Tools/Building
+Summary:	Lorem ipsum
+License:	GPL-2.0+
+BuildRoot:	%_tmppath/%name-%version-build
+Url:            http://www.opensuse.org/
+BuildArch:      noarch
+
+%description
+Lorem ipsum dolor sit amet, consectetur adipisici elit, sed
+eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim
+ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquid ex ea commodi consequat. Quis aute iure reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui
+officia deserunt mollit anim id est laborum.
+
+%prep
+%build
+
+%install
+install -d -m 755 %buildroot/usr/lib/tmpfiles.d
+cat > %buildroot/usr/lib/tmpfiles.d/foo.conf << EOF
+d /var/log/foo  0755  root  root  10d
+EOF
+
+%clean
+rm -rf %buildroot
+
+%post
+%tmpfiles_create foo.conf
+
+%files
+%defattr(-,root,root)
+/usr/lib/tmpfiles.d
+%ghost /var/log/foo
+
+%changelog
+* Mon Apr 18 2011 lnussel@suse.de
+- dummy


### PR DESCRIPTION
Test that rpmlint doesn't give any warning when %tmpfiles_create is
used with a basename filename, which is correct usage.

This is a test for https://github.com/openSUSE/rpmlint-checks/pull/39