### PR TITLE
pie.spec: use /usr/bin/mount, since /bin/mount was removed from permissions

### DIFF
--- a/tests/pie.ref
+++ b/tests/pie.ref
@@ -1,4 +1,4 @@
-pie: W: missing-call-to-setgroups-before-setuid /bin/mount
-pie: W: permissions-incorrect /bin/mount has mode 0755 but should be 04755
+pie: W: missing-call-to-setgroups-before-setuid /usr/bin/mount
+pie: W: permissions-incorrect /usr/bin/mount has mode 0755 but should be 04755
 pie: E: non-position-independent-executable (Badness: 10000) /usr/bin/telnet
 1 packages and 0 specfiles checked; 1 errors, 2 warnings.

--- a/tests/pie.spec
+++ b/tests/pie.spec
@@ -24,7 +24,7 @@ mkdir -p %buildroot/usr/bin/
 echo "int main() {}" >xx.c
 gcc -O2 -fno-PIE xx.c -o     %buildroot/usr/bin/telnet
 strip %buildroot/usr/bin/telnet
-install -D -m 755 /bin/mount %buildroot/bin/mount
+install -D -m 755 /bin/mount %buildroot/usr/bin/mount
 
 
 %clean
@@ -33,7 +33,7 @@ rm -rf %buildroot
 %files
 %defattr(-,root,root)
 /usr/bin/telnet
-/bin/mount
+/usr/bin/mount
 
 %changelog
 * Mon Apr 18 2011 lnussel@suse.de


### PR DESCRIPTION
This should fix rpmlint-tests in Factory that currently fail, because stale entries have been removed from the permissions package.