### PR TITLE
libzork4.spec: removed define for 'basename' in libzork4.spec

### DIFF
--- a/tests/libzork4.spec
+++ b/tests/libzork4.spec
@@ -1,5 +1,4 @@
 %define soname 42
-%define basename zork
 
 Name:           zork4
 Version:        1.2.3


### PR DESCRIPTION
This causes build errors because 'basename' is a builtin and it's not used