### PR TITLE
test for new file-parent-ownership-mismatch lint

### DIFF
--- a/tests/mixed-file-owners.ignore
+++ b/tests/mixed-file-owners.ignore
@@ -1,0 +1,1 @@
+addFilter(" no-binary")

--- a/tests/mixed-file-owners.ref
+++ b/tests/mixed-file-owners.ref
@@ -1,0 +1,2 @@
+mixed-file-owners: W: file-parent-ownership-mismatch /usr/share/foo/bar owned by root is stored in directory owned by different user bin
+1 packages and 0 specfiles checked; 0 errors, 1 warnings.

--- a/tests/mixed-file-owners.spec
+++ b/tests/mixed-file-owners.spec
@@ -1,0 +1,41 @@
+#
+# spec file for package mixed-file-owners
+#
+# Copyright (c) 2019 SUSE LLC.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:           mixed-file-owners
+Version:        1
+Release:        0
+Summary:        Test package with a file hierarchy with mixed users
+License:        GPL-2.0+
+Url:            https://www.opensuse.org/
+
+%description
+description of the package that is longer than the summary so it has some filler text
+
+%install
+mkdir -p ${RPM_BUILD_ROOT}/%_datadir/foo/{bar,baz}
+
+%files
+%dir %attr(-,bin,root) %_datadir/foo
+# bad: user 'foo' has control over root-owned file
+%dir %attr(-,root,root) %_datadir/foo/bar
+# good: file owner matches dir owner
+%dir %attr(-,bin,root) %_datadir/foo/baz
+
+%changelog
+* Fri Jan 17 2020 malte.kraus@suse.com
+ - change history of the spec


### PR DESCRIPTION
integration test for https://github.com/openSUSE/rpmlint-checks/pull/53