### PR TITLE
Add integration test with Github Actions

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,0 +1,6 @@
+FROM opensuse/tumbleweed
+
+RUN zypper in -y --no-recommends rpmlint-Factory-strict rpmlint-Factory rpmlint-mini rpmbuild git erlang
+COPY integration_test.sh /integration_test.sh
+
+ENTRYPOINT ["/integration_test.sh"]

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,6 +1,8 @@
 FROM opensuse/tumbleweed
 
-RUN zypper in -y --no-recommends rpmlint-Factory-strict rpmlint-Factory rpmlint-mini rpmbuild git erlang
+# erlang is required for some tests
+# gcc-PIE is needed, because default GCC doesn't create PIE binaries and we don't want to trigger position-independent-executable-suggested
+RUN zypper -q --color in -y --no-recommends rpmlint-Factory-strict rpmlint-Factory rpmlint-mini rpmbuild git erlang gcc-PIE colordiff
 COPY integration_test.sh /integration_test.sh
 
 ENTRYPOINT ["/integration_test.sh"]

--- a/.github/action.yml
+++ b/.github/action.yml
@@ -1,0 +1,5 @@
+name: 'Integration test'
+description: 'Clones this repo and rpmlint-checks and runs ./run'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -3,13 +3,28 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -x
+#set -x
+
+cyan() {
+    printf "\e[36m\e[1m%s\e[m\x0f\n" "$@"
+}
+
+echo
+
 
 cd "$GITHUB_WORKSPACE/.."
 # If someone does changes to -tests and -checks at the same time, we want to test them together.
 # So try cloning a branch with the same name of the same owner. If that fails, just clone current master.
-git clone --depth 1 -b "${GITHUB_REF##*/}" "https://github.com/${GITHUB_REPOSITORY//-tests/-checks}.git" ||
-    git clone --depth 1 -b master "https://github.com/openSUSE/rpmlint-checks.git"
+git clone -q --depth 1 -b "${GITHUB_REF##*/}" "https://github.com/${GITHUB_REPOSITORY//-tests/-checks}.git" ||
+    git clone -q --depth 1 -b master "https://github.com/openSUSE/rpmlint-checks.git"
+
+branch_info=$(git -C rpmlint-checks branch -r -v | cut -d/ -f 2-)
+branch_name=$(echo "$branch_info" | cut '-d ' -f 1)
+branch_commit_id=$(echo "$branch_info" | cut '-d ' -f 2)
+branch_commit_msg=$(echo "$branch_info" | cut '-d ' -f 3-)
+remote=$(git -C rpmlint-checks remote get-url origin)
+echo "testing against rpmlint-checks branch $branch_name from $remote / commit $branch_commit_id: '$branch_commit_msg'"
+
 
 for f in rpmlint-checks/*.py ; do
     # 'install' checks from git
@@ -18,10 +33,15 @@ for f in rpmlint-checks/*.py ; do
     # force-enable all checks, to test them even before they're added to rpmlint-Factory
     basename="${f##*/}"
     without_ext="${basename%.*}"
-    echo "addCheck('$without_ext')" >> /opt/testing/share/rpmlint/config
+    [[ "$without_ext" != "Whitelisting" ]] &&
+        echo "addCheck('$without_ext')" >> /opt/testing/share/rpmlint/config
 done
-# dunno why this is required, but tests fail without this
-echo "addFilter(' position-independent-executable-suggested ')" >> /opt/testing/share/rpmlint/config
 
 cd "$GITHUB_WORKSPACE"
-./run
+cyan "Starting testsuite..."
+
+# run the testsuite, overriding the 'diff' command to 'colordiff'
+bash -c 'diff() {
+    colordiff "$@"
+}
+source ./run'

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
+
+cd "$GITHUB_WORKSPACE/.."
+# If someone does changes to -tests and -checks at the same time, we want to test them together.
+# So try cloning a branch with the same name of the same owner. If that fails, just clone current master.
+git clone --depth 1 -b "${GITHUB_REF##*/}" "https://github.com/${GITHUB_REPOSITORY//-tests/-checks}.git" ||
+    git clone --depth 1 -b master "https://github.com/openSUSE/rpmlint-checks.git"
+
+for f in rpmlint-checks/*.py ; do
+    # 'install' checks from git
+    mv "$f" /opt/testing/share/rpmlint/
+
+    # force-enable all checks, to test them even before they're added to rpmlint-Factory
+    basename="${f##*/}"
+    without_ext="${basename%.*}"
+    echo "addCheck('$without_ext')" >> /opt/testing/share/rpmlint/config
+done
+# dunno why this is required, but tests fail without this
+echo "addFilter(' position-independent-executable-suggested ')" >> /opt/testing/share/rpmlint/config
+
+cd "$GITHUB_WORKSPACE"
+./run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: integration test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout
+
+    - uses: './.github/'
+      name: Run script


### PR DESCRIPTION
This adds a CI like was suggested in openSUSE/rpmlint-checks#14 using Github Actions

Here is an example CI run:
https://github.com/maltek/rpmlint-tests/runs/451150539?check_suite_focus=true

Note that this force-enables all lints, even those not part of `rpmlint-factory-strict`. That's kind of wrong (it differs from how this is run in OBS), on the other hand it's the only way to actually test that new tests for new lints actually work. We may actually want to have two CI jobs here, one that does enables all lints and one that runs with an unmodified configuration so that we see immediately that `rpmlint-factory` needs adjustment before a new test should be pushed to OBS.

This also requires https://github.com/maltek/rpmlint-checks/commit/c6c1a037cc1d56f8fdb1a443468827629e2a7140 For whatever reason, this is currently fixed in rpm415-workaround.diff in OBS and not in our git repository...